### PR TITLE
Fix an error while running this under docker-compose 1.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ mysql:
     MYSQL_DATABASE: teamcity
     MYSQL_USER: teamcity
     MYSQL_PASSWORD: teamcity
-    MYSQL_ALLOW_EMPTY_PASSWORD: yes
+    MYSQL_ALLOW_EMPTY_PASSWORD: 1
 agentone:
   privileged: true
   image: alexanderilyin/docker-teamcity-agent


### PR DESCRIPTION
```
$ docker-compose up
ERROR: Validation failed in file './docker-compose.yml', reason(s):
mysql.environment.MYSQL_ALLOW_EMPTY_PASSWORD contains true, which is an invalid type, it should be a string, number, or a null
```
